### PR TITLE
changes to address improved asesthetics

### DIFF
--- a/spline_cluster_detector/app.R
+++ b/spline_cluster_detector/app.R
@@ -43,7 +43,7 @@ ui <- page(
     ),
     nav_spacer(),
     nav_item(report_ui("report")),
-    nav_item(input_dark_mode(mode="dark")),
+    nav_item(input_dark_mode()),
     navbar_options = list(class = "bg-primary", theme = "dark", underline=FALSE)
   )
 )

--- a/spline_cluster_detector/src/01_credentials.R
+++ b/spline_cluster_detector/src/01_credentials.R
@@ -32,8 +32,8 @@ get_profile <- function(
 
   provide_credentials <- rstudioapi::showQuestion(
     title = title, 
-    message = "Do you want to provide credentials?",
-    "Provide credentials", "Use local file upload only"
+    message = "App Mode (API Usage vs Local File Only):",
+    "Utilize API to Input Data", "Use local data files only"
   )
   
   if(!provide_credentials) return(list(

--- a/spline_cluster_detector/src/modules/cluster_line_listing_module.R
+++ b/spline_cluster_detector/src/modules/cluster_line_listing_module.R
@@ -31,7 +31,7 @@ cluster_line_listing_ui <- function(id) {
             "Choose Cluster Center(s)",
             choices=NULL
           )),
-          hidden(input_switch(ns("unmask"), "Show Actual Values", value=FALSE)),
+          hidden(input_switch(ns("unmask"), "Show Actual Values", value=TRUE)),
           style = "overflow: visible"
         ),
         style = "overflow: visible"
@@ -159,7 +159,7 @@ cluster_line_listing_server <- function(id, results, dc, cc, profile, recompute)
       observe(toggleElement("cluster_ll_card", condition=!is.null(nrow(ll_data()))))
       # hide the ll center selector if no ll_data()
       observe(toggleElement("ll_cluster_selector", condition=!is.null(nrow(ll_data()))))
-      observe(toggleElement("unmask", condition=!is.null(nrow(ll_data()))))
+      #observe(toggleElement("unmask", condition=!is.null(nrow(ll_data()))))
       
       # hide the generate LL button if no clusters
       observe(toggleElement("generate_ll_task", condition=conditions_met()))

--- a/spline_cluster_detector/src/modules/data_explorer_module.R
+++ b/spline_cluster_detector/src/modules/data_explorer_module.R
@@ -62,7 +62,7 @@ data_explorer_ui <- function(id) {
         card(
           full_screen = TRUE, 
           min_height = "500px",
-          plotlyOutput(ns("heatmap")),
+          withSpinner(plotlyOutput(ns("heatmap")), caption="Heatmap Loading"),
           option_controls,
           class = 'bg-transparent border-0'
         )
@@ -72,7 +72,7 @@ data_explorer_ui <- function(id) {
         card(
           full_screen=TRUE,
           min_height = "500px",
-          plotlyOutput(ns("tSeries")),
+          withSpinner(plotlyOutput(ns("tSeries")), caption="Time Series Loading"),
           class = 'bg-transparent border-0'
         )
       )

--- a/spline_cluster_detector/src/modules/data_loader_sidebar_module.R
+++ b/spline_cluster_detector/src/modules/data_loader_sidebar_module.R
@@ -173,7 +173,7 @@ dl_sidebar_ui <- function(id) {
       inputId = ns("local_or_nssp"),
       label = labeltt(sb_ll[["local_or_nssp"]]),
       choices = c("Local File" = "local", "NSSP API Call" = "nssp"),
-      selected = "local",
+      selected = "nssp",
       inline = TRUE
     ),
     conditionalPanel(
@@ -238,6 +238,8 @@ dl_sidebar_server <- function(id, dc, cc, profile, valid_profile) {
           HTML(paste0("<p style='color:red'>", custom_url_valid(), "</p>"))
         }
       })
+      
+      observe(if(!valid_profile()) updateRadioButtons(inputId = "local_or_nssp", selected="local"))
 
       ns=session$ns
 

--- a/spline_cluster_detector/src/modules/ingest_data_module.R
+++ b/spline_cluster_detector/src/modules/ingest_data_module.R
@@ -29,12 +29,12 @@ ingested_data_ui <- function(id) {
   hidden(div(
     id = ns("ingest_data_card"),
     card(
+      card_header("Counts by Location and Date",class = "bg-primary"),
       id = ns("ingest_data_card"),
-      min_height = 300,
-      withSpinner(
-        dataTableOutput(ns("inputdata"))
-        # ,caption = "Loading Data (API calls can take some time)"
-      ),
+      max_height = 800,
+      full_screen = TRUE,
+      withSpinner(dataTableOutput(ns("inputdata")), 
+                  caption = "Loading Data (API calls can take some time)"),
       card_footer(
         downloadButton(ns("download_ingested_data"), "Download Data", class = "btn-primary btn-sm"),
         actionButton(ns("url"), "Show URL/Source Path", class = "btn-primary btn-sm")
@@ -67,7 +67,7 @@ ingested_data_server <- function(id, profile,  results, dc, cc, ibc, parent_sess
         cc$distance_locations <- dl()$loc_vec
         cc$distance_matrix <- dl()$distance_matrix
       })
-      
+    
       # Hide the data card if the global reactive use nssp changes
       observe(hideElement("ingest_data_card")) |> bindEvent(dc$USE_NSSP)
       
@@ -167,7 +167,7 @@ ingested_data_server <- function(id, profile,  results, dc, cc, ibc, parent_sess
             update_task_button(session = parent_session, "ingest_btn",state="ready")
             toggle_task_button_color(parent_session$ns("ingest_btn"), busy=FALSE)
           }
-          
+            
         )
         
         
@@ -186,7 +186,7 @@ ingested_data_server <- function(id, profile,  results, dc, cc, ibc, parent_sess
         
         if(dc$USE_NSSP) message <- dt_events()$description
         else message <- "LOCAL FILE SELECTED/LOADED"
-        
+
         showModal( 
           modalDialog( 
             title = "Data Source (Esc to Close)",
@@ -208,7 +208,8 @@ ingested_data_server <- function(id, profile,  results, dc, cc, ibc, parent_sess
         datatable(
           dt_events()$data[count>0, list(display_name, date, count)],
           colnames = c("Location", "Date", "Count"),
-          rownames = FALSE
+          rownames = FALSE,
+          options = list(pageLength=20)
         ) 
       },server=TRUE) 
       


### PR DESCRIPTION
This PR addresses the following issues:

 - fixes the wording on the initial request to make it clear that we first ask whether or not the user wants to use the app in "local only" mode vs "using the API" mode
 - On the landing page of the app, we default to using the API vs the local file upload option, (unless of course the user has requested to use the app in local mode)
 - We no longer explicitly set the `input_dark_mode` mode to `"dark"`. Rather, we don't set it at all, and it should use the user's default system setting (this is not extensively tested on my end, but appears to work for me. that is, whe my Windows settings->personalization->colors-> mode is set to dark, the shiny app launches in dark mode; when it is set to light, the app launches in light mode.). The user can still manually toggle it, of course
 - We add spinners, with captions for the heatmap and time series to notify the user if these are loading
 - The ability to mask the line listing values is now hidden (not removed), but completely inaccessible to the user, and we just show the actual values
 - The max height on the data ingest is set, which prompts a scroll bar, and there is a `card_header()` added, to bring it more into alignment with other DT

thanks to @rosericazondekon  for all these suggestions.
