### PR TITLE
turn off deduplication by default and add tooltip

### DIFF
--- a/spline_cluster_detector/src/helpers/01_helper_functions.R
+++ b/spline_cluster_detector/src/helpers/01_helper_functions.R
@@ -221,7 +221,7 @@ deduplicate_datadetails <- function(
   setDT(data) |>
     # 1. filter out certain types
     _[!grepl(excl_fac_types, FacilityType,ignore.case = T)] |>
-    # 3. deduplicate
+    # 2. deduplicate
     _[order(Date), .SD[1], .(Visit_ID, Hospital)]
   
 }

--- a/spline_cluster_detector/src/modules/data_loader_sidebar_module.R
+++ b/spline_cluster_detector/src/modules/data_loader_sidebar_module.R
@@ -71,7 +71,13 @@ sb_ll <- list(
     baseline_length = list(
       l = "Baseline Length",
       m = paste0("Number of days in the baseline interval (min 1, max ", MAX_DATE_RANGE, ")")
+    ),
+    dedup = list(
+      l = "De-duplicate?",
+      m = "De-duplicates encounters by taking the first (chronological) encounter within VisitID and Hospital.
+      The default behavior is to NOT de-duplicate."
     )
+    
     
     
 )
@@ -121,7 +127,7 @@ dl_sidebar_ui <- function(id) {
     ),
     conditionalPanel(
       condition = "input.data_type == 'details'",
-      input_switch(id = ns("dedup"), label = "De-duplicate?", value=TRUE),
+      input_switch(id = ns("dedup"), label = labeltt(sb_ll[["dedup"]]), value=FALSE),
       ns=ns
     )
   )


### PR DESCRIPTION
 - turns the default behavior of the `de-duplication` capability to OFF.  thanks to Andrew Farrey.
 - adds a tool tip to better describe the de-duplication procedure