### PR TITLE
updated test length max from 28 to 90; updated change log

### DIFF
--- a/spline_cluster_detector/src/documentation/change_log.Rmd
+++ b/spline_cluster_detector/src/documentation/change_log.Rmd
@@ -9,6 +9,11 @@ output:
     toc_depth: 3
 ---
 
+## September 29th, 2025
+
+-   The maximum cluster length / test interval has been increased to 90 days.
+
+
 ## September 4th, 2025
 
 -   All queries generated from the API Builder (whether data details or table builder) by default use the `hasBeenE` flag. This can now be turned off in the Advanced Options, if desired.

--- a/spline_cluster_detector/src/modules/clustering_sidebar_module.R
+++ b/spline_cluster_detector/src/modules/clustering_sidebar_module.R
@@ -111,7 +111,7 @@ clust_sidebar_ui <- function(id) {
           inputId = ns("test_length"),
           label = labeltt(clsb_ll[["test_length"]]),
           min = 1,
-          max = 28,
+          max = 90,
           value = 7
         ),
         numericInput(


### PR DESCRIPTION
  - Updates the maximum test length interval (i.e. cluster duration) from 28 days to 90 days
  - Adds entry in ChangeLog