### PR TITLE
3 change baseline adjustment method

### DIFF
--- a/spline_cluster_detector/src/modules/clustering_sidebar_module.R
+++ b/spline_cluster_detector/src/modules/clustering_sidebar_module.R
@@ -33,7 +33,7 @@ clsb_ll <- list(
     l = "Baseline Adjustment Method",
     m = "Method used to adjust the baseline counts to avoid divide-by-zero issues in estimating the log(observed/expected).
       Choices include: add a constant (1) to the expected only when otherwise a divide-by-zero would occur; include
-      the test interval data in the baseline counts, and no adjustment.
+      the test interval data in the baseline counts (default), and no adjustment.
       "
   ),
   spline = list(
@@ -72,9 +72,9 @@ clust_sidebar_ui <- function(id) {
     inputId = ns("base_adj_meth"),
     label = labeltt(clsb_ll[["base_adj_meth"]]),
     choices = c("Add One As Needed" = "add_one",
-      # "Add One to All Locations" = "add_one_global",
       "Add Test Data to Baseline" = "add_test",
-      "No Adjustment" = "none")
+      "No Adjustment" = "none"),
+    selected = "add_test"
   )
 
   adv_acc_panel <- accordion_panel(

--- a/spline_cluster_detector/src/modules/data_explorer_module.R
+++ b/spline_cluster_detector/src/modules/data_explorer_module.R
@@ -188,14 +188,12 @@ data_explorer_server <- function(id, results, dc, cc) {
             cc$end_date
           )
         )
-        print(relevant_dates)
-
+        
         # updates choices
         choices = unique(
           results$filtered_records_count[between(date, relevant_dates[1], relevant_dates[2])] |> 
             _[count>0, .(location, display_name)]
         )
-        print(choices)
         
         # add the "All" option, and return
         c("All" = "All", setNames(

--- a/spline_cluster_detector/src/scd_package_assets/cluster_functions.R
+++ b/spline_cluster_detector/src/scd_package_assets/cluster_functions.R
@@ -348,16 +348,6 @@ generate_observed_expected <- function(
   )]
 
   # add the log of observed to expected
-  if (adjust == TRUE) {
-    dt_cases_grid_clust[, log_obs_exp := data.table::fifelse(
-      expected == 0,
-      log(observed / (expected + adj_constant)),
-      log(observed / expected)
-    )]
-  } else {
-    dt_cases_grid_clust[, log_obs_exp := log(observed / expected)]
-  }
-
   dt_cases_grid_clust[, log_obs_exp := data.table::fifelse(
     expected == 0 & adjust == TRUE,
     log(observed / (expected + adj_constant)),


### PR DESCRIPTION
 - sets the default baseline adjustment method to "add_test"
 - removes two print statements
 - removes duplicated expected calculation